### PR TITLE
Update to invoker.lua

### DIFF
--- a/Scripts/invoker.lua
+++ b/Scripts/invoker.lua
@@ -202,7 +202,7 @@ end
  
 -- Chaos Meteor - Deafening Blast
 function MeteorBlastCombo( )
-        queue = {wee,{"wait",1450},qwe}
+        queue = {wee,{"wait",700},qwe}
 end
  
 -- Cold Snap - Forge Spirit - Alacrity
@@ -212,7 +212,16 @@ end
  
 -- Eul - Sun Strike - Chaos Meteor - Deafening Blast
 function EulSSMeteorBlast( )
-        queue = {{"item_unit","item_cyclone"},{"wait",800},eee,{"wait",400},wee,{"wait",1000},qwe}
+        if target then
+            local me = entityList:GetMyHero()
+            local cyclone = me:FindItem("item_cyclone")
+            if cyclone and cyclone:CanBeCasted() then
+                me:CastAbility(cyclone, target)
+                return
+			end
+		else
+			 queue = {{"item_unit","item_cyclone"},{"wait",1000},eee,{"wait",400},wee,qwe}
+        end		
 end
  
 -- Tornado - EMP - Chaos Meteor - Deafening Blast
@@ -439,6 +448,24 @@ function Tick( tick )
                 end
                         text.text = hkey
         end
+		if target~= nil and me then
+		    local cycloneModif = target:FindModifier("modifier_eul_cyclone")
+		    if cycloneModif then
+		        if cycloneModif.remainingTime < 1.80 then 
+                    queue = {eee} 
+			    end
+		    end
+		    if cycloneModif then
+		        if cycloneModif.remainingTime < 1.3 then 
+                    queue = {wee} 
+			    end
+		    end
+            if cycloneModif then
+		        if cycloneModif.remainingTime < 0.6 then 
+                    queue = {qwe} --I'm not much of scripter per say, so this might seem odd the way I separated it, but it works much better.
+			    end
+		    end
+	    end			
 end
  
 --Invokes the input combination


### PR DESCRIPTION
This fixes the Eul combo, the problem was that euls itself has a range of 700, so casting out of this range would cause sunstrike to hit too early, furthermore the rest of the combo was too slow allowing a person to escape, this improves the timing of the combo and fixes the distance issue, also you can now use the combo on a target even if you didn't cast the euls per say, or let's say the target casts euls on himself, it would automatically queue to invoke the combo.

I'm planning on making more changes, just seems that you've been inactive a while and was wondering if I could take over the script.
